### PR TITLE
[Browserstack] Add: disableAutoMarkStatus flag

### DIFF
--- a/packages/wdio-browserstack-service/browserstack-service.d.ts
+++ b/packages/wdio-browserstack-service/browserstack-service.d.ts
@@ -41,7 +41,7 @@ interface BrowserstackConfig {
      */
     opts?: Partial<import('browserstack-local').Options>,
     /**
-     * Set this to false if you don't want test status on browserstack to be marked automatically based on test results
+     * Set this to true if you don't want test status on browserstack to be marked automatically based on test results
      */
      disableAutoMarkStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/browserstack-service.d.ts
+++ b/packages/wdio-browserstack-service/browserstack-service.d.ts
@@ -39,5 +39,9 @@ interface BrowserstackConfig {
      * Specified optional will be passed down to BrowserstackLocal. See this list for details:
      * https://stackoverflow.com/questions/39040108/import-class-in-definition-file-d-ts
      */
-    opts?: Partial<import('browserstack-local').Options>
+    opts?: Partial<import('browserstack-local').Options>,
+    /**
+     * Set this to false if you don't want test status on browserstack to be marked automatically based on test results
+     */
+     disableAutoMarkStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -108,7 +108,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         if (this._options.preferScenarioName && this._scenariosThatRan.length === 1){
             this._fullTitle = this._scenariosThatRan.pop()
         }
-        if(!this._options.disableAutoMarkStatus){
+        if (!this._options.disableAutoMarkStatus){
             const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
             jobUpdates['reason'] = hasReasons ? this._failReasons.join('\n') : undefined
             jobUpdates['status'] = result === 0 ? 'passed' : 'failed'

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -101,19 +101,20 @@ export default class BrowserstackService implements Services.ServiceInstance {
     }
 
     after (result: number) {
+
+        let jobUpdates = {}
         // For Cucumber: Checks scenarios that ran (i.e. not skipped) on the session
         // Only 1 Scenario ran and option enabled => Redefine session name to Scenario's name
         if (this._options.preferScenarioName && this._scenariosThatRan.length === 1){
             this._fullTitle = this._scenariosThatRan.pop()
         }
-
-        const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
-
-        return this._updateJob({
-            status: result === 0 ? 'passed' : 'failed',
-            name: this._fullTitle,
-            reason: hasReasons ? this._failReasons.join('\n') : undefined
-        })
+        if(!this._options.disableAutoMarkStatus){
+            const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
+            jobUpdates['reason'] = hasReasons ? this._failReasons.join('\n') : undefined
+            jobUpdates['status'] = result === 0 ? 'passed' : 'failed'
+        }
+        jobUpdates['name'] = this._fullTitle
+        return this._updateJob(jobUpdates)
     }
 
     /**

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -36,5 +36,9 @@ export interface BrowserstackConfig {
      * }
      * ```
      */
-    opts?: Partial<import('browserstack-local').Options>
+    opts?: Partial<import('browserstack-local').Options>,
+    /**
+     * Set this to false if you don't want test status on browserstack to be marked automatically based on test results
+     */
+    disableAutoMarkStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -38,7 +38,7 @@ export interface BrowserstackConfig {
      */
     opts?: Partial<import('browserstack-local').Options>,
     /**
-     * Set this to false if you don't want test status on browserstack to be marked automatically based on test results
+     * Set this to true if you don't want test status on browserstack to be marked automatically based on test results
      */
     disableAutoMarkStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -41,12 +41,14 @@ beforeEach(() => {
         isMultiremote: false,
         browserA: {
             sessionId: 'session456',
-            capabilities: { 'bstack:options': {
-                device: '',
-                os: 'Windows',
-                osVersion: 10,
-                browserName: 'chrome'
-            } }
+            capabilities: {
+                'bstack:options': {
+                    device: '',
+                    os: 'Windows',
+                    osVersion: 10,
+                    browserName: 'chrome'
+                }
+            }
         },
         browserB: {}
     } as any as Browser
@@ -484,11 +486,13 @@ describe('after', () => {
             })
         expect(got.put).toHaveBeenCalledWith(
             'https://api.browserstack.com/automate/sessions/session123.json',
-            { json: {
-                status: 'passed',
-                name: 'foo - bar',
-                reason: undefined
-            }, username: 'foo', password: 'bar' })
+            {
+                json: {
+                    status: 'passed',
+                    name: 'foo - bar',
+                    reason: undefined
+                }, username: 'foo', password: 'bar'
+            })
     })
     it('should call _update when session has errors (exit code 1)', async () => {
         const updateSpy = jest.spyOn(service, '_update')
@@ -506,11 +510,13 @@ describe('after', () => {
             })
         expect(got.put).toHaveBeenCalledWith(
             'https://api.browserstack.com/automate/sessions/session123.json',
-            { json: {
-                status: 'failed',
-                name: 'foo - bar',
-                reason: 'I am failure'
-            }, username: 'foo', password: 'bar' })
+            {
+                json: {
+                    status: 'failed',
+                    name: 'foo - bar',
+                    reason: 'I am failure'
+                }, username: 'foo', password: 'bar'
+            })
     })
     describe('Cucumber only', function () {
         it('should call _update with status "failed" if strict mode is "on" and all tests are pending', async () => {
@@ -522,17 +528,17 @@ describe('after', () => {
             await service.before(service['_config'], [], browser)
             await service.beforeFeature(null, { name: 'Feature1' })
 
-            await service.afterScenario({ pickle: { name: 'Can do something but pending 1' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but pending 3' },  result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending 1' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending 3' }, result: { status: 'PENDING' } })
 
             await service.after(1)
 
             expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
                 name: 'Feature1',
                 reason: 'Some steps/hooks are pending for scenario "Can do something but pending 1"' + '\n' +
-                        'Some steps/hooks are pending for scenario "Can do something but pending 2"' + '\n' +
-                        'Some steps/hooks are pending for scenario "Can do something but pending 3"',
+                    'Some steps/hooks are pending for scenario "Can do something but pending 2"' + '\n' +
+                    'Some steps/hooks are pending for scenario "Can do something but pending 3"',
                 status: 'failed',
             })
             expect(updateSpy).toHaveBeenCalled()
@@ -547,9 +553,9 @@ describe('after', () => {
             await service.before(service['_config'], [], browser)
             await service.beforeFeature(null, { name: 'Feature1' })
 
-            await service.afterScenario({ pickle: { name: 'Can do something' },  result: { status: 'PASSED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something' },  result: { status: 'PASSED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something' }, result: { status: 'PASSED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something' }, result: { status: 'PASSED' } })
 
             await service.after(0)
 
@@ -570,9 +576,9 @@ describe('after', () => {
             await service.before(service['_config'], [], browser)
             await service.beforeFeature(null, { name: 'Feature1' })
 
-            await service.afterScenario({ pickle: { name: 'Can do something 1' },  result: { status: 'PASSED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but pending' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something 2' },  result: { status: 'PASSED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something 1' }, result: { status: 'PASSED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something 2' }, result: { status: 'PASSED' } })
 
             await service.after(1)
 
@@ -590,9 +596,9 @@ describe('after', () => {
             await service.before(service['_config'], [], browser)
             await service.beforeFeature(null, { name: 'Feature1' })
 
-            await service.afterScenario({ pickle: { name: 'Can do something skipped 1' },  result: { status: 'SKIPPED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something skipped 2' },  result: { status: 'SKIPPED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something skipped 3' },  result: { status: 'SKIPPED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something skipped 1' }, result: { status: 'SKIPPED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something skipped 2' }, result: { status: 'SKIPPED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something skipped 3' }, result: { status: 'SKIPPED' } })
 
             await service.after(0)
 
@@ -618,9 +624,9 @@ describe('after', () => {
                 name: 'Feature1'
             })
 
-            await service.afterScenario({ pickle: { name: 'Can do something failed 1' },  result: { message: 'I am error, hear me roar', status: 'FAILED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but passed 3' },  result: { status: 'SKIPPED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something failed 1' }, result: { message: 'I am error, hear me roar', status: 'FAILED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but passed 3' }, result: { status: 'SKIPPED' } })
 
             await service.after(1)
 
@@ -648,9 +654,9 @@ describe('after', () => {
                 name: 'Feature1'
             })
 
-            await service.afterScenario({ pickle: { name: 'Can do something failed 1' },  result: { message: 'I am error, hear me roar', status: 'FAILED' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' },  result: { status: 'PENDING' } })
-            await service.afterScenario({ pickle: { name: 'Can do something but passed 3' },  result: { status: 'SKIPPED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something failed 1' }, result: { message: 'I am error, hear me roar', status: 'FAILED' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but pending 2' }, result: { status: 'PENDING' } })
+            await service.afterScenario({ pickle: { name: 'Can do something but passed 3' }, result: { status: 'SKIPPED' } })
 
             await service.after(1)
 
@@ -667,20 +673,24 @@ describe('after', () => {
         describe('preferScenarioName', () => {
             describe('enabled', () => {
                 [
-                    { status: 'FAILED', body: {
-                        name: 'Feature1',
-                        reason: 'Unknown Error',
-                        status: 'failed',
-                    } },
-                    { status: 'SKIPPED', body: {
-                        name: 'Can do something single',
-                        reason: undefined,
-                        status: 'failed',
-                    } }
+                    {
+                        status: 'FAILED', body: {
+                            name: 'Feature1',
+                            reason: 'Unknown Error',
+                            status: 'failed',
+                        }
+                    },
+                    {
+                        status: 'SKIPPED', body: {
+                            name: 'Can do something single',
+                            reason: undefined,
+                            status: 'failed',
+                        }
+                    }
                     /*, 5, 4, 0*/
                 ].map(({ status, body }) =>
                     it(`should call _update /w status failed and name of Scenario when single "${status}" Scenario ran`, async () => {
-                        service = new BrowserstackService({ preferScenarioName : true }, [] as any,
+                        service = new BrowserstackService({ preferScenarioName: true }, [] as any,
                             { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                         service.before({}, [], browser)
 
@@ -695,7 +705,7 @@ describe('after', () => {
                 )
 
                 it('should call _update /w status passed and name of Scenario when single "passed" Scenario ran', async () => {
-                    service = new BrowserstackService({ preferScenarioName : true }, [] as any,
+                    service = new BrowserstackService({ preferScenarioName: true }, [] as any,
                         { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                     service.before({}, [], browser)
 
@@ -718,7 +728,7 @@ describe('after', () => {
             describe('disabled', () => {
                 ['FAILED', 'AMBIGUOUS', 'UNDEFINED', 'UNKNOWN'].map(status =>
                     it(`should call _update /w status failed and name of Feature when single "${status}" Scenario ran`, async () => {
-                        service = new BrowserstackService({ preferScenarioName : false }, [] as any,
+                        service = new BrowserstackService({ preferScenarioName: false }, [] as any,
                             { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                         service.before({}, [], browser)
 
@@ -739,7 +749,7 @@ describe('after', () => {
                 )
 
                 it('should call _update /w status passed and name of Feature when single "passed" Scenario ran', async () => {
-                    service = new BrowserstackService({ preferScenarioName : false }, [] as any,
+                    service = new BrowserstackService({ preferScenarioName: false }, [] as any,
                         { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                     service.before({}, [], browser)
 
@@ -761,121 +771,121 @@ describe('after', () => {
                 })
             })
 
-            describe("disableAutoMarkStatus",()=>{
-                describe('disabled',()=>{
+            describe('disableAutoMarkStatus', () => {
+                describe('disabled', () => {
                     [{
-                        status:"FAILED", body: { 
+                        status: 'FAILED', body: {
                             name: 'Feature1',
                             reason: 'Unknown Error',
                             status: 'failed'
                         }
-                    },{
-                        status:"SKIPPED", body: {
+                    }, {
+                        status: 'SKIPPED', body: {
                             name: 'Can do something single',
                             reason: undefined,
                             status: 'failed',
                         }
-                    }].map(({status,body})=>{
-                        it(`should call _update /w status failed and name of Scenario when single "${status}" Scenario ran`,async ()=>{
-                            service = new BrowserstackService({ preferScenarioName : true,disableAutoMarkStatus:false }, [] as any,
+                    }].map(({ status, body }) => {
+                        it(`should call _update /w status failed and name of Scenario when single "${status}" Scenario ran`, async () => {
+                            service = new BrowserstackService({ preferScenarioName: true, disableAutoMarkStatus: false }, [] as any,
                                 { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                             service.before({}, [], browser)
-    
+
                             const updateSpy = jest.spyOn(service, '_update')
-    
+
                             await service.beforeFeature(null, { name: 'Feature1' })
                             await service.afterScenario({ pickle: { name: 'Can do something single' }, result: { status } })
                             await service.after(1)
-    
+
                             expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, body)
-                        })  
+                        })
                     })
                 })
-                describe('enabled',()=>{
+                describe('enabled', () => {
                     [{
-                        status:"FAILED", body: { 
+                        status: 'FAILED', body: {
                             name: 'Feature1',
                             reason: 'Unknown Error',
                             status: 'failed'
                         }
-                    },{
-                        status:"SKIPPED", body: {
+                    }, {
+                        status: 'SKIPPED', body: {
                             name: 'Can do something single',
                             reason: undefined,
                             status: 'failed',
                         }
-                    }].map(({status,body})=>{
-                        it(`should call _update /w status failed and name of Scenario when single "${status}" Scenario ran`,async ()=>{
-                            service = new BrowserstackService({ preferScenarioName : true,disableAutoMarkStatus:true }, [] as any,
+                    }].map(({ status, body }) => {
+                        it(`should call _update /w status failed and name of Scenario when single "${status}" Scenario ran`, async () => {
+                            service = new BrowserstackService({ preferScenarioName: true, disableAutoMarkStatus: true }, [] as any,
                                 { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                             service.before({}, [], browser)
-    
+
                             const updateSpy = jest.spyOn(service, '_update')
-    
+
                             await service.beforeFeature(null, { name: 'Feature1' })
                             await service.afterScenario({ pickle: { name: 'Can do something single' }, result: { status } })
                             await service.after(1)
-    
+
                             expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
-                                name:body.name
+                                name: body.name
                             })
-                        })  
+                        })
                     })
                 })
             })
         })
     })
-    describe("disableAutoMarkStatus",()=>{
-        describe('disabled',()=>{
+    describe('disableAutoMarkStatus', () => {
+        describe('disabled', () => {
             [{
                 name: 'I pass the test',
                 reason: undefined,
                 status: 'passed',
-            },{
+            }, {
                 name: 'I fail the test',
-                reason: "I Failed",
+                reason: 'I Failed',
                 status: 'failed',
-            }].map((body)=>{
-                it(`should call _update /w status ${body.status} when single "${body.status}" test ran`,async ()=>{
-                    service = new BrowserstackService({ disableAutoMarkStatus:false }, [] as any,
+            }].map((body) => {
+                it(`should call _update /w status ${body.status} when single "${body.status}" test ran`, async () => {
+                    service = new BrowserstackService({ disableAutoMarkStatus: false }, [] as any,
                         { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                     service.before({}, [], browser)
-    
+
                     service['_fullTitle'] = body.name
-                    service['_failReasons'] = body.reason?[body.reason]:[]
-    
+                    service['_failReasons'] = body.reason ? [body.reason] : []
+
                     const updateSpy = jest.spyOn(service, '_update')
-                    const result = body.status == "passed"?0:1
+                    const result = body.status == 'passed' ? 0 : 1
                     await service.after(result)
                     expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, body)
-                })  
+                })
             })
         })
-        describe('enabled',()=>{
+        describe('enabled', () => {
             [{
                 name: 'I pass the test',
                 reason: undefined,
                 status: 'passed',
-            },{
+            }, {
                 name: 'I fail the test',
-                reason: "I Failed",
+                reason: 'I Failed',
                 status: 'failed',
-            }].map((body)=>{
-                it(`should call _update /w status ${body.status} when single "${body.status}" test ran`,async ()=>{
-                    service = new BrowserstackService({ disableAutoMarkStatus:true }, [] as any,
+            }].map((body) => {
+                it(`should call _update /w status ${body.status} when single "${body.status}" test ran`, async () => {
+                    service = new BrowserstackService({ disableAutoMarkStatus: true }, [] as any,
                         { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
                     service.before({}, [], browser)
-    
+
                     service['_fullTitle'] = body.name
-                    service['_failReasons'] = body.reason?[body.reason]:[]
-    
+                    service['_failReasons'] = body.reason ? [body.reason] : []
+
                     const updateSpy = jest.spyOn(service, '_update')
-                    const result = body.status == "passed"?0:1
+                    const result = body.status == 'passed' ? 0 : 1
                     await service.after(result)
                     expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
-                        name:body.name
+                        name: body.name
                     })
-                })  
+                })
             })
         })
     })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

Current Browserstack service automatically marks the status of the test giving no freedom to mark own status or format the reason. Browserstack service overrides the status even if it was marked using javascript executor. Hence adding disableAutoMarkStatus flag should solve this.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
